### PR TITLE
[typescript] Changed SettingsUI.d.ts to use more common ES6 style exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "unpkg": "dist/index.umd.js",
+  "types": "src/SettingsUI.d.ts",
   "scripts": {
     "build": "microbundle && npm run build:example",
     "build:dev": "microbundle watch -f es -o example/dist/index.mjs",

--- a/src/SettingsUI.d.ts
+++ b/src/SettingsUI.d.ts
@@ -1,0 +1,117 @@
+declare module 'settings-ui';
+
+interface renderResult {
+  /**
+   * Renders to a specific HTML element.
+   * @param element Element to render the UI in.
+   */
+  to: (element: HTMLElement) => HTMLElement;
+  /**
+   * Similar to to(element) but replaces the element with the generated UI.
+   * @param element Element to render the UI in.
+   */
+  replace: (element: HTMLElement) => HTMLElement;
+  /**
+   * Returns the generated element without appending it to the dom.
+   * @returns Returns the generated element without appending it to the dom.
+   */
+  get: () => HTMLElement;
+}
+
+interface templateEntry {
+  /**
+   * Required Used as property names for the store and for ids in HTML.
+   */
+  id: string;
+  /**
+   * Help text. Used for titles or placeholders
+   */
+  help?: string;
+  /**
+   * Defines value type.
+   * Falls back to default HTML input types. These also define that type of element is generated.
+   */
+  type?: 'number' | 'text' | 'boolean' | 'selection' | string;
+  /**
+   * Currently not used by core components.
+   */
+  description?: string;
+  /**
+   * Short description. Used mainly for labels.
+   */
+  name?: string;
+  /**
+   * For number: lowest possible number, for text: minimal character length.
+   */
+  min?: number;
+  /**
+   * For number: highest possible number, for text: max character length.
+   */
+  max?: number;
+  /**
+   * For number: Available steps for inputting numbers.
+   */
+  steps?: number;
+  /**
+   * Forces input element to specific type
+   */
+  inputType?: 'input' | 'radio' | 'selection';
+  /**
+   * Value that is used when no value has been set. E.g. when clearing an input field, this value is set.
+   */
+  defaultValue?: string;
+
+  /**
+   * Defines a set of possible values. Generates a HTML <select> or <input type="radio/>" element.
+   * Each value can be a direct value or an object with a name and value property.
+   * @example [{name: 'one', value: 1}]
+   */
+  values?: { name: string; value: any }[];
+  /**
+   * For type = "section": Defines subtypes for a section.
+   */
+  options?: any[];
+  /**
+   * Function that is called whenever the value changes.
+   * Called with the new value as parameter.
+   */
+  onUpdate?: (newValue: any) => void;
+}
+
+interface settingsUI {
+  bind: (template: templateEntry[], config = {}) => config;
+  /**
+   * Adds a listener that is called every time a value was updated.
+   */
+  addChangeListener: (listener: (id: string, value: any) => void) => void;
+  /**
+   * Removes a change listener.
+   */
+  removeChangeListener: (listener: (id: string, value: any) => void) => void;
+  /**
+   * Renders the UI.
+   */
+  render: (tag = 'div') => renderResult;
+}
+
+interface pluginResult {
+  htmlElements?: HTMLElement[];
+  superType?: boolean;
+}
+
+/**
+ * @param templateEntry A single entry from the template array.,
+ * @param update A function that updates the form data.
+ */
+interface plugin {
+  (
+    templateEntry: templateEntry,
+    update: (value: string) => void
+  ): pluginResult | null | void;
+}
+
+interface settingsUIArguments {
+  plugins: plugin[];
+}
+
+export = function (options: settingsUIArguments = {}): settingsUI {};

--- a/src/SettingsUI.d.ts
+++ b/src/SettingsUI.d.ts
@@ -141,4 +141,4 @@ interface settingsUIArguments {
 }
 
 declare function SettingsUI(options?: settingsUIArguments): settingsUI;
-export = SettingsUI;
+export default SettingsUI;


### PR DESCRIPTION
Before, settings-ui could only be imported by typescript with the esModuleInterop flag set to true. Changed the exports to to ES6 style, because the TS compiler understands those by default and they are more commonly used.